### PR TITLE
fix

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -135,7 +135,10 @@ function parseSheet(sheet, setting) {
     let row = sheet.data[i_row];
 
     let parsed_row = parseRow(row, i_row, setting.head);
-
+    if (!parsed_row) {
+      console.log("err null row:", i_row + 1)
+      continue;
+    }
     if (setting.type === SheetType.MASTER) {
 
       let id_cell = _.find(setting.head, item => {
@@ -167,6 +170,7 @@ function parseRow(row, rowIndex, head) {
   let result = {};
   let id;
 
+  let isAllNull = true;
   for (let index = 0; index < head.length; index++) {
     let cell = row[index];
 
@@ -181,6 +185,8 @@ function parseRow(row, rowIndex, head) {
       result[name] = null;
       continue;
     }
+
+    isAllNull = false
 
     switch (type) {
       case DataType.ID:
@@ -241,7 +247,10 @@ function parseRow(row, rowIndex, head) {
     }
   }
 
-  return result;
+  if (isAllNull)
+    return null;
+  else
+    return result;
 }
 
 /**


### PR DESCRIPTION
如果导出的JSON文件尾行出现value都是null的数据，可能是因为excel中数据没删除干净，看控制台打印的行数据条目数和实际符不符合可判定。修复此条注意过滤掉没有数据的行